### PR TITLE
Update run.sh to fix error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,10 +8,10 @@ curl -LJo plugins/atlas.jar https://github.com/Avicus/Atlas/releases/download/2.
 
 # Sets
 mkdir -p plugins/Atlas/all-module-sets
-curl -LJo plugins/all-module-sets/arcade.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-arcade-2.0.0.jar
-curl -LJo plugins/all-module-sets/comp-objectives.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-competitive-objectives-2.0.0.jar
-curl -LJo plugins/all-module-sets/generator.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-docs-generator-2.0.0.jar
-curl -LJo plugins/all-module-sets/walls.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-walls-2.0.0.jar
+curl -LJo plugins/Atlas/all-module-sets/arcade.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-arcade-2.0.0.jar
+curl -LJo plugins/Atlas/all-module-sets/comp-objectives.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-competitive-objectives-2.0.0.jar
+curl -LJo plugins/Atlas/all-module-sets/generator.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-docs-generator-2.0.0.jar
+curl -LJo plugins/Atlas/all-module-sets/walls.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-walls-2.0.0.jar
 
 # Pull in server
 curl -LJo magnet.jar https://github.com/Avicus/Magnet/releases/download/1.8.8/magnet-1.8.8-R0.1-SNAPSHOT.jar

--- a/run.sh
+++ b/run.sh
@@ -7,11 +7,11 @@ curl -LJo plugins/tracker.jar https://github.com/Avicus/Tracker/releases/downloa
 curl -LJo plugins/atlas.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-core-2.0.0.jar
 
 # Sets
-mkdir -p plugins/Atlas/all-module-sets
-curl -LJo plugins/Atlas/all-module-sets/arcade.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-arcade-2.0.0.jar
-curl -LJo plugins/Atlas/all-module-sets/comp-objectives.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-competitive-objectives-2.0.0.jar
-curl -LJo plugins/Atlas/all-module-sets/generator.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-docs-generator-2.0.0.jar
-curl -LJo plugins/Atlas/all-module-sets/walls.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-walls-2.0.0.jar
+mkdir -p plugins/all-module-sets
+curl -LJo plugins/all-module-sets/arcade.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-arcade-2.0.0.jar
+curl -LJo plugins/all-module-sets/comp-objectives.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-competitive-objectives-2.0.0.jar
+curl -LJo plugins/all-module-sets/generator.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-docs-generator-2.0.0.jar
+curl -LJo plugins/all-module-sets/walls.jar https://github.com/Avicus/Atlas/releases/download/2.0.0/atlas-walls-2.0.0.jar
 
 # Pull in server
 curl -LJo magnet.jar https://github.com/Avicus/Magnet/releases/download/1.8.8/magnet-1.8.8-R0.1-SNAPSHOT.jar


### PR DESCRIPTION
Fixes issue where there is no directory found, due to all-module-sets dir created inside Atlas folder. Makes it easier to run this repo "out of the box" as users don't have to manually recreate this folder